### PR TITLE
Fixes for Windows

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -62,13 +62,13 @@ function createQuery (queryPath, babelPath) {
           if (subFragments.length > 0) {
             processImports(subFragments, absFragmentPath)
           }
-          fragmentDefs = [...gql`${fragmentSource}`.definitions,...fragmentDefs]
+          fragmentDefs = [...gql`${fragmentSource}`.definitions, ...fragmentDefs]
         })
       }
     },
-    parse() {
+    parse () {
       const parsedAST = gql`${source}`
-      parsedAST.definitions = [...parsedAST.definitions,...fragmentDefs]
+      parsedAST.definitions = [...parsedAST.definitions, ...fragmentDefs]
       ast = parsedAST
     },
     dedupeFragments () {

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,85 +1,102 @@
-import path, { dirname } from 'path'
-import { EOL } from 'os'
-import { readFileSync } from 'fs'
-import { parse } from 'babylon'
-import gql from 'graphql-tag'
+import path, { dirname } from 'path';
+import { EOL } from 'os';
+import { readFileSync } from 'fs';
+import { parse } from 'babylon';
+import gql from 'graphql-tag';
 
-let resolve
+let resolve;
 
 export default ({ types: t }) => ({
-  manipulateOptions ({ resolveModuleSource }) {
+  manipulateOptions({ resolveModuleSource }) {
     if (!resolve) {
-      resolve = resolveModuleSource || ((src, file) => path.resolve(dirname(file), src))
+      resolve =
+        resolveModuleSource ||
+        ((src, file) => path.resolve(dirname(file), src));
     }
   },
   visitor: {
     ImportDeclaration: {
-      exit (curPath, state) {
-        const importPath = curPath.node.source.value
+      exit(curPath, state) {
+        const importPath = curPath.node.source.value;
         if (importPath.endsWith('.graphql') || importPath.endsWith('.gql')) {
-          const query = createQuery(importPath, state.file.opts.filename)
-          query.processFragments()
-          query.parse()
-          query.dedupeFragments()
-          query.makeSourceEnumerable()
-          curPath.replaceWith(buildInlineVariableAST(query.ast))
+          const query = createQuery(importPath, state.file.opts.filename);
+          query.processFragments();
+          query.parse();
+          query.dedupeFragments();
+          query.makeSourceEnumerable();
+          curPath.replaceWith(buildInlineVariableAST(query.ast));
         }
 
-        function buildInlineVariableAST (graphqlAST) {
-          const inlineVarName = curPath.node.specifiers[0].local.name
-          return parse(`const ${inlineVarName} = ${JSON.stringify(graphqlAST)}`).program.body[0]
+        function buildInlineVariableAST(graphqlAST) {
+          const inlineVarName = curPath.node.specifiers[0].local.name;
+          return parse(`const ${inlineVarName} = ${JSON.stringify(graphqlAST)}`)
+            .program.body[0];
         }
       }
     }
   }
-})
+});
 
-function createQuery (queryPath, babelPath) {
-  const absPath = resolve(queryPath, babelPath)
-  const source = readFileSync(absPath).toString()
-  let ast = null
-  let fragmentDefs = []
+function createQuery(queryPath, babelPath) {
+  const absPath = resolve(queryPath, babelPath);
+  const source = readFileSync(absPath).toString();
+  let ast = null;
+  let fragmentDefs = [];
 
   return {
-    processFragments () {
-      processImports(getImportStatements(source), absPath)
+    processFragments() {
+      processImports(getImportStatements(source), absPath);
 
-      function getImportStatements (src) {
-        return src.split(EOL).filter(line => line.startsWith('#import'))
+      function getImportStatements(src) {
+        return src
+          .replace(/\r/g, '')
+          .split(/\n+/g)
+          .filter(line => line.startsWith('#import'));
       }
 
-      function processImports (imports, relFile) {
+      function processImports(imports, relFile) {
         imports.forEach(statement => {
-          const fragmentPath = statement.split(/\s+/g)[1].slice(1, -1)
-          const absFragmentPath = resolve(fragmentPath, relFile)
-          const fragmentSource = readFileSync(absFragmentPath).toString()
-          const subFragments = getImportStatements(fragmentSource)
+          const fragmentPath = statement.split(/[\s\n]+/g)[1].slice(1, -1);
+          const absFragmentPath = resolve(fragmentPath, relFile);
+          const fragmentSource = readFileSync(
+            absFragmentPath.replace(/'/g, '')
+          ).toString();
+          const subFragments = getImportStatements(fragmentSource);
           if (subFragments.length > 0) {
-            processImports(subFragments, absFragmentPath)
+            processImports(subFragments, absFragmentPath);
           }
-          fragmentDefs = [...gql`${fragmentSource}`.definitions, ...fragmentDefs]
-        })
+          fragmentDefs = [
+            ...gql`
+              ${fragmentSource}
+            `.definitions,
+            ...fragmentDefs
+          ];
+        });
       }
     },
-    parse () {
-      const parsedAST = gql`${source}`
-      parsedAST.definitions = [...parsedAST.definitions, ...fragmentDefs]
-      ast = parsedAST
+    parse() {
+      const parsedAST = gql`
+        ${source}
+      `;
+      parsedAST.definitions = [...parsedAST.definitions, ...fragmentDefs];
+      ast = parsedAST;
     },
-    dedupeFragments () {
-      let seenNames = {}
+    dedupeFragments() {
+      let seenNames = {};
       ast.definitions = ast.definitions.filter(def => {
-        if (def.kind !== 'FragmentDefinition') return true
-        return seenNames[def.name.value] ? false : (seenNames[def.name.value] = true)
-      })
+        if (def.kind !== 'FragmentDefinition') return true;
+        return seenNames[def.name.value]
+          ? false
+          : (seenNames[def.name.value] = true);
+      });
     },
-    makeSourceEnumerable () {
-      const newAST = JSON.parse(JSON.stringify(ast))
-      newAST.loc.source = ast.loc.source
-      ast = newAST
+    makeSourceEnumerable() {
+      const newAST = JSON.parse(JSON.stringify(ast));
+      newAST.loc.source = ast.loc.source;
+      ast = newAST;
     },
-    get ast () {
-      return ast
+    get ast() {
+      return ast;
     }
-  }
+  };
 }

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -67,10 +67,8 @@ function createQuery (queryPath, babelPath) {
       }
     },
     parse() {
-      const parsedAST = gql`
-        ${source}
-      `
-      parsedAST.definitions = [...parsedAST.definitions, ...fragmentDefs]
+      const parsedAST = gql`${source}`
+      parsedAST.definitions = [...parsedAST.definitions,...fragmentDefs]
       ast = parsedAST
     },
     dedupeFragments () {

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -7,15 +7,14 @@ import gql from 'graphql-tag'
 let resolve
 
 export default ({ types: t }) => ({
-  manipulateOptions({ resolveModuleSource }) {
+  manipulateOptions ({ resolveModuleSource }) {
     if (!resolve) {
-      resolve =
-        resolveModuleSource || ((src, file) => path.resolve(dirname(file), src))
+      resolve = resolveModuleSource || ((src, file) => path.resolve(dirname(file), src))
     }
   },
   visitor: {
     ImportDeclaration: {
-      exit(curPath, state) {
+      exit (curPath, state) {
         const importPath = curPath.node.source.value
         if (importPath.endsWith('.graphql') || importPath.endsWith('.gql')) {
           const query = createQuery(importPath, state.file.opts.filename)
@@ -26,34 +25,33 @@ export default ({ types: t }) => ({
           curPath.replaceWith(buildInlineVariableAST(query.ast))
         }
 
-        function buildInlineVariableAST(graphqlAST) {
+        function buildInlineVariableAST (graphqlAST) {
           const inlineVarName = curPath.node.specifiers[0].local.name
-          return parse(`const ${inlineVarName} = ${JSON.stringify(graphqlAST)}`)
-            .program.body[0]
+          return parse(`const ${inlineVarName} = ${JSON.stringify(graphqlAST)}`).program.body[0]
         }
       }
     }
   }
 })
 
-function createQuery(queryPath, babelPath) {
+function createQuery (queryPath, babelPath) {
   const absPath = resolve(queryPath, babelPath)
   const source = readFileSync(absPath).toString()
   let ast = null
   let fragmentDefs = []
 
   return {
-    processFragments() {
+    processFragments () {
       processImports(getImportStatements(source), absPath)
 
-      function getImportStatements(src) {
+      function getImportStatements (src) {
         return src
           .replace(/\r/g, '')
           .split(/\n+/g)
           .filter(line => line.startsWith('#import'))
       }
 
-      function processImports(imports, relFile) {
+      function processImports (imports, relFile) {
         imports.forEach(statement => {
           const fragmentPath = statement.split(/[\s\n]+/g)[1].slice(1, -1)
           const absFragmentPath = resolve(fragmentPath, relFile)
@@ -64,12 +62,7 @@ function createQuery(queryPath, babelPath) {
           if (subFragments.length > 0) {
             processImports(subFragments, absFragmentPath)
           }
-          fragmentDefs = [
-            ...gql`
-              ${fragmentSource}
-            `.definitions,
-            ...fragmentDefs
-          ]
+          fragmentDefs = [...gql`${fragmentSource}`.definitions,...fragmentDefs]
         })
       }
     },
@@ -80,21 +73,19 @@ function createQuery(queryPath, babelPath) {
       parsedAST.definitions = [...parsedAST.definitions, ...fragmentDefs]
       ast = parsedAST
     },
-    dedupeFragments() {
+    dedupeFragments () {
       let seenNames = {}
       ast.definitions = ast.definitions.filter(def => {
         if (def.kind !== 'FragmentDefinition') return true
-        return seenNames[def.name.value]
-          ? false
-          : (seenNames[def.name.value] = true)
+        return seenNames[def.name.value] ? false : (seenNames[def.name.value] = true)
       })
     },
-    makeSourceEnumerable() {
+    makeSourceEnumerable () {
       const newAST = JSON.parse(JSON.stringify(ast))
       newAST.loc.source = ast.loc.source
       ast = newAST
     },
-    get ast() {
+    get ast () {
       return ast
     }
   }

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,102 +1,101 @@
-import path, { dirname } from 'path';
-import { EOL } from 'os';
-import { readFileSync } from 'fs';
-import { parse } from 'babylon';
-import gql from 'graphql-tag';
+import path, { dirname } from 'path'
+import { EOL } from 'os'
+import { readFileSync } from 'fs'
+import { parse } from 'babylon'
+import gql from 'graphql-tag'
 
-let resolve;
+let resolve
 
 export default ({ types: t }) => ({
   manipulateOptions({ resolveModuleSource }) {
     if (!resolve) {
       resolve =
-        resolveModuleSource ||
-        ((src, file) => path.resolve(dirname(file), src));
+        resolveModuleSource || ((src, file) => path.resolve(dirname(file), src))
     }
   },
   visitor: {
     ImportDeclaration: {
       exit(curPath, state) {
-        const importPath = curPath.node.source.value;
+        const importPath = curPath.node.source.value
         if (importPath.endsWith('.graphql') || importPath.endsWith('.gql')) {
-          const query = createQuery(importPath, state.file.opts.filename);
-          query.processFragments();
-          query.parse();
-          query.dedupeFragments();
-          query.makeSourceEnumerable();
-          curPath.replaceWith(buildInlineVariableAST(query.ast));
+          const query = createQuery(importPath, state.file.opts.filename)
+          query.processFragments()
+          query.parse()
+          query.dedupeFragments()
+          query.makeSourceEnumerable()
+          curPath.replaceWith(buildInlineVariableAST(query.ast))
         }
 
         function buildInlineVariableAST(graphqlAST) {
-          const inlineVarName = curPath.node.specifiers[0].local.name;
+          const inlineVarName = curPath.node.specifiers[0].local.name
           return parse(`const ${inlineVarName} = ${JSON.stringify(graphqlAST)}`)
-            .program.body[0];
+            .program.body[0]
         }
       }
     }
   }
-});
+})
 
 function createQuery(queryPath, babelPath) {
-  const absPath = resolve(queryPath, babelPath);
-  const source = readFileSync(absPath).toString();
-  let ast = null;
-  let fragmentDefs = [];
+  const absPath = resolve(queryPath, babelPath)
+  const source = readFileSync(absPath).toString()
+  let ast = null
+  let fragmentDefs = []
 
   return {
     processFragments() {
-      processImports(getImportStatements(source), absPath);
+      processImports(getImportStatements(source), absPath)
 
       function getImportStatements(src) {
         return src
           .replace(/\r/g, '')
           .split(/\n+/g)
-          .filter(line => line.startsWith('#import'));
+          .filter(line => line.startsWith('#import'))
       }
 
       function processImports(imports, relFile) {
         imports.forEach(statement => {
-          const fragmentPath = statement.split(/[\s\n]+/g)[1].slice(1, -1);
-          const absFragmentPath = resolve(fragmentPath, relFile);
+          const fragmentPath = statement.split(/[\s\n]+/g)[1].slice(1, -1)
+          const absFragmentPath = resolve(fragmentPath, relFile)
           const fragmentSource = readFileSync(
             absFragmentPath.replace(/'/g, '')
-          ).toString();
-          const subFragments = getImportStatements(fragmentSource);
+          ).toString()
+          const subFragments = getImportStatements(fragmentSource)
           if (subFragments.length > 0) {
-            processImports(subFragments, absFragmentPath);
+            processImports(subFragments, absFragmentPath)
           }
           fragmentDefs = [
             ...gql`
               ${fragmentSource}
             `.definitions,
             ...fragmentDefs
-          ];
-        });
+          ]
+        })
       }
     },
     parse() {
       const parsedAST = gql`
         ${source}
-      `;
-      parsedAST.definitions = [...parsedAST.definitions, ...fragmentDefs];
-      ast = parsedAST;
+      `
+      parsedAST.definitions = [...parsedAST.definitions, ...fragmentDefs]
+      ast = parsedAST
     },
     dedupeFragments() {
-      let seenNames = {};
+      let seenNames = {}
       ast.definitions = ast.definitions.filter(def => {
-        if (def.kind !== 'FragmentDefinition') return true;
+        if (def.kind !== 'FragmentDefinition') return true
         return seenNames[def.name.value]
           ? false
-          : (seenNames[def.name.value] = true);
-      });
+          : (seenNames[def.name.value] = true)
+      })
     },
     makeSourceEnumerable() {
-      const newAST = JSON.parse(JSON.stringify(ast));
-      newAST.loc.source = ast.loc.source;
-      ast = newAST;
+      const newAST = JSON.parse(JSON.stringify(ast))
+      newAST.loc.source = ast.loc.source
+      ast = newAST
     },
     get ast() {
-      return ast;
+      return ast
     }
-  };
+  }
 }


### PR DESCRIPTION
Hi, been following the issues and changes made as of late and appreciate them, however, I am still dealing with a couple of issue that I am having to modify manually in your module. Keep in mind I develop on a windows system which is the source of many of the issues

1) getImportStatements function: you have it as
`function getImportStatements(src) {
        return src.split(_os.EOL).filter(function(line) {
          return line.startsWith('#import');
        });
      }`

However, depending on your IDE settings sometimes its just '\n' in your files even if your are on a windows machine. to fix this and make it compatible with POSIX and windows as well as various IDE settings i think it should be:
`function getImportStatements(src) {
        return src
          .replace(/\r/g, '')
          .split(/\n+/g)
          .filter(function(line) {
            return line.startsWith('#import');
          });
      }`

2) controversial perhaps, but some people use single quotes not double. the result is that not all single quotes are currently removed. Changing the following in function processImports:
`var fragmentSource = (0, _fs.readFileSync)(
            absFragmentPath
          ).toString();`

to

`var fragmentSource = (0, _fs.readFileSync)(
            absFragmentPath.replace(/'/g, '')
          ).toString();`

fixes this

3) lastly the most recent change to processImports where fragmentPath looks like this:
`var fragmentPath = statement.split(/\s+/g)[1].slice(1, -1);`

was great, however, I had issues with it probably due to my use of prettier where it was grabbing more than just the import, updating it to:
`var fragmentPath = statement.split(/[\s\n]+/g)[1].slice(1, -1);`
fixed the issue for me